### PR TITLE
Make info card responsive

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,8 +1,14 @@
-    #personal-info-card {
+#personal-info-card {
   background: radial-gradient(ellipse at center, rgba(230, 237, 243, 0.05) 0%, var(--card) 70%);
-  width: 1200px;
+  max-width: 100%;
   height: auto;
   padding: 60px;
+}
+
+@media (min-width: 1200px) {
+  #personal-info-card {
+    width: 1200px;
+  }
 }
 
 @keyframes pulse {


### PR DESCRIPTION
## Summary
- Make personal info card flexible by default with `max-width: 100%`
- Add media query to reapply `width: 1200px` on large screens

## Testing
- `node <<'NODE'
const fs = require('fs');
const puppeteer = require('puppeteer');
const css = fs.readFileSync('/workspace/minato-makoto.github.io/css/main.css', 'utf8');
(async () => {
  async function measure(width) {
    const browser = await puppeteer.launch({args:['--no-sandbox']});
    const page = await browser.newPage();
    await page.setViewport({width, height: 800});
    const html = `<style>${css}</style><div id="personal-info-card">Card</div>`;
    await page.setContent(html, { waitUntil: 'domcontentloaded' });
    const cardWidth = await page.$eval('#personal-info-card', el => el.clientWidth);
    await browser.close();
    return cardWidth;
  }
  const viewports = [360, 768, 1200, 1600];
  for (const width of viewports) {
    const w = await measure(width);
    console.log(`${width}px viewport -> card width ${w}px`);
  }
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b160b511248325a293c2ec2deb44d8