### PR TITLE
Load memory asynchronously during init

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -477,8 +477,8 @@ async function loadMemory(){
 }
 
 async function init(){
-  await loadMemory();
-  boot();
+  boot();          // gắn sự kiện click ngay lập tức
+  loadMemory();    // tải JSON song song, không chặn UI
 }
 
 window.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- Start UI boot immediately in `init` and fetch memory JSON in parallel to avoid blocking user interaction.

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1696f9efc832581429576cdeb2805