### PR TITLE
fix: remove stray closing span in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       <!-- Help overlay removed -->
     </div>
 
-    <div class="footer">© 𝜋.𝟹.𝟷𝟺</span> 𐕣 2025</div>
+    <div class="footer">© 𝜋.𝟹.𝟷𝟺 𐕣 2025</div>
   </div>
 
   <div id="toast" class="toast" role="status" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- remove stray closing span tag in footer of index.html

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b16973ce308325a4a1fb067cad23b5