### PR TITLE
refactor: unify Three.js CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>ID_SYNC_INDEX v4.20 — Veiled ⇄ 3D FUSION (Compat + Kaomoji.AI)</title>
 
-<!-- Perf: preconnect to CDNs -->
-<link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+<!-- Perf: preconnect to CDN -->
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 
 <style>
@@ -234,14 +233,14 @@
       <!-- Help overlay removed -->
     </div>
 
-    <div class="footer">© 𝜋.𝟹.𝟷𝟺</span> 𐕣 2025</div>
+    <div class="footer">© 𝜋.𝟹.𝟷𝟺 𐕣 2025</div>
   </div>
 
   <div id="toast" class="toast" role="status" aria-live="polite"></div>
   <textarea id="hiddenJson" class="hidden" aria-hidden="true"></textarea>
 
   <!-- Three.js + Controls + CSS3DRenderer (deferred) -->
-  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/renderers/CSS3DRenderer.js"></script>
 


### PR DESCRIPTION
## Summary
- consolidate to jsDelivr CDN for Three.js, OrbitControls, and CSS3DRenderer
- remove unused cdnjs preconnect and clean up footer tag

## Testing
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b16c10b934832592f6985dab4c01c1