### PR TITLE
Add SRI integrity to Three.js CDN scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,9 +240,9 @@
   <textarea id="hiddenJson" class="hidden" aria-hidden="true"></textarea>
 
   <!-- Three.js + Controls + CSS3DRenderer (deferred) -->
-  <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/renderers/CSS3DRenderer.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js" integrity="sha384-CI3ELBVUz9XQO+97x6nwMDPosPR5XvsxW2ua7N1Xeygeh1IxtgqtCkGfQY9WWdHu" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js" integrity="sha384-wagZhIFgY4hD+7awjQjR4e2E294y6J2HSnd8eTNc15ZubTeQeVRZwhQJ+W6hnBsf" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/renderers/CSS3DRenderer.js" integrity="sha384-9VT8doZsDBlrp8/yB8FemEtIm616pA2epE7X2SR6VXCdmuqlMRV/dkCiaRNWPhl1" crossorigin="anonymous"></script>
 
 <script>
 // --- Burst style helper ---


### PR DESCRIPTION
## Summary
- add SHA-384 integrity and crossorigin attributes to Three.js, OrbitControls, and CSS3DRenderer CDN scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b178e46ee08325b3ec805eab872e01