### PR TITLE
chore: update social preview image urls

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,11 +10,11 @@
   <meta property="og:url" content="https://minato-makoto.github.io/">
   <meta property="og:title" content="Minato Makoto | Interactive 3D Portfolio">
   <meta property="og:description" content="Portfolio 3D tương tác của Lương Bảo Huy (Minato Makoto), Video Producer, Photographer, Designer.">
-  <meta property="og:image" content="URL_ảnh_preview.png">
+  <meta property="og:image" content="https://minato-makoto.github.io/src/assets/images/og-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Minato Makoto | Interactive 3D Portfolio">
   <meta name="twitter:description" content="Portfolio 3D tương tác của Lương Bảo Huy (Minato Makoto), Video Producer, Photographer, Designer.">
-  <meta name="twitter:image" content="URL_ảnh_preview.png">
+  <meta name="twitter:image" content="https://minato-makoto.github.io/src/assets/images/og-preview.jpg">
   <meta name="robots" content="noindex">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -10,11 +10,11 @@
   <meta property="og:url" content="https://minato-makoto.github.io/">
   <meta property="og:title" content="Minato Makoto | Interactive 3D Portfolio">
   <meta property="og:description" content="Portfolio 3D tương tác của Lương Bảo Huy (Minato Makoto), Video Producer, Photographer, Designer.">
-  <meta property="og:image" content="URL_ảnh_preview.png">
+  <meta property="og:image" content="https://minato-makoto.github.io/src/assets/images/og-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Minato Makoto | Interactive 3D Portfolio">
   <meta name="twitter:description" content="Portfolio 3D tương tác của Lương Bảo Huy (Minato Makoto), Video Producer, Photographer, Designer.">
-  <meta name="twitter:image" content="URL_ảnh_preview.png">
+  <meta name="twitter:image" content="https://minato-makoto.github.io/src/assets/images/og-preview.jpg">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>


### PR DESCRIPTION
## Summary
- point og:image and twitter:image to the hosted preview image

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c032b9aea883259d1c1b7776887044