### PR TITLE
Remove math formula text glow

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -42,7 +42,7 @@
   position: absolute;
   font-family: 'VT323', monospace;
   color: var(--terminal-white);
-  text-shadow: 0 0 5px var(--terminal-white);
+  text-shadow: none;
   opacity: 0;
   mask-image: linear-gradient(to left, transparent 60%, black 40%);
   -webkit-mask-image: linear-gradient(to left, transparent 60%, black 40%);


### PR DESCRIPTION
## Summary
- eliminate glow effect on math formulas by disabling text-shadow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c03cdf96b0832580de764c4f8aeb11