### PR TITLE
Delay formula fade-out for smoother wipe

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -70,10 +70,11 @@
 :host .math-formula.visible { opacity: 0.24; }
 
 :host .math-formula.fading-out {
-  transition: mask-position 1.5s;
-  -webkit-transition: -webkit-mask-position 1.5s;
+  transition: mask-position 1.5s, opacity 1.5s;
+  -webkit-transition: -webkit-mask-position 1.5s, opacity 1.5s;
   mask-position: 0% 0%;
   -webkit-mask-position: 0% 0%;
+  opacity: 0;
 }
 
 /* Transition for fade-out effect */

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -300,12 +300,15 @@ export class AppComponent implements AfterViewInit, OnDestroy {
 
     this.renderer2.appendChild(container, span);
 
-    requestAnimationFrame(() => this.renderer2.addClass(span, 'visible'));
-
     const formula = this.nextFormula();
-    await this.typeFormula(span, formula, 40);
 
-    this.renderer2.addClass(span, 'fading-out');
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => {
+        this.renderer2.addClass(span, 'visible');
+        this.typeFormula(span, formula, 40).then(resolve);
+      });
+    });
+
     const unlisten = this.renderer2.listen(span, 'transitionend', () => {
       unlisten();
       if (span.parentNode) {
@@ -313,6 +316,8 @@ export class AppComponent implements AfterViewInit, OnDestroy {
       }
     });
     this._listeners.push(unlisten);
+
+    setTimeout(() => this.renderer2.addClass(span, 'fading-out'), 300);
   }
 
   // --- Boot Logic ---


### PR DESCRIPTION
## Summary
- start formula typing only after visibility begins so characters appear with the fade-in
- delay before removing formulas and fade out both opacity and mask to make wipe visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c03ce165dc8325901c09125ed4e20f