### PR TITLE
Speed up formula rotation

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -50,7 +50,7 @@
   -webkit-mask-size: 200% 100%;
   mask-position: 100% 0%;
   -webkit-mask-position: 100% 0%;
-  transition: opacity 1.5s;
+  transition: opacity 0.6s;
 }
 
 :host .math-formula::after {
@@ -70,8 +70,8 @@
 :host .math-formula.visible { opacity: 0.24; }
 
 :host .math-formula.fading-out {
-  transition: mask-position 1.5s;
-  -webkit-transition: -webkit-mask-position 1.5s;
+  transition: mask-position 0.6s;
+  -webkit-transition: -webkit-mask-position 0.6s;
   mask-position: 0% 0%;
   -webkit-mask-position: 0% 0%;
 }

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -247,7 +247,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     if (this.router.url !== '/') return;
     this.boot();
     this.spawnFormula();
-    this.formulaInterval = setInterval(() => this.spawnFormula(), 4000);
+    this.formulaInterval = setInterval(() => this.spawnFormula(), 1800);
   }
 
   ngOnDestroy(): void {
@@ -305,7 +305,12 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     const formula = this.nextFormula();
     await this.typeFormula(span, formula, 40);
 
-    this.renderer2.addClass(span, 'fading-out');
+    const fadeTimer = setTimeout(() => {
+      this.renderer2.addClass(span, 'fading-out');
+      this.typingTimers.delete(fadeTimer);
+    }, 700);
+    this.typingTimers.add(fadeTimer);
+
     const unlisten = this.renderer2.listen(span, 'transitionend', () => {
       unlisten();
       if (span.parentNode) {


### PR DESCRIPTION
## Summary
- reduce formula interval to 1.8s and delay fade-out by 700ms for faster cycling
- shorten formula opacity and mask transitions to 0.6s for quicker removal

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c03ce1f1748325b247db9e421be49b