### PR TITLE
feat: add background formula animation

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -46,6 +46,33 @@
   opacity: 0;
 }
 
+/* Background formulas overlay */
+:host #veiled-container > .background-formulas {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+
+:host .math-formula {
+  position: absolute;
+  color: var(--terminal-green);
+  font-family: 'Cambria Math', 'Times New Roman', serif;
+  font-size: 24px;
+  opacity: 0;
+  white-space: nowrap;
+  transition: opacity 1.5s linear;
+}
+
+:host .math-formula.visible {
+  opacity: 1;
+}
+
+:host .math-formula.fading-out {
+  opacity: 0;
+}
+
 :host .title-veiled {
   font-family: 'VT323', monospace;
   color: var(--terminal-white);
@@ -80,8 +107,7 @@
   font-size: 28px;
 }
 
-:host #btn-activate,
-:host #btn-mobile {
+:host #btn-activate {
   font-family: 'VT323', monospace;
   background: none;
   border: none;
@@ -98,42 +124,34 @@
 }
 
 :host #btn-activate::before,
-:host #btn-activate::after,
-:host #btn-mobile::before,
-:host #btn-mobile::after {
+:host #btn-activate::after {
   content: '';
   opacity: 0;
 }
 
-:host #btn-activate::before,
-:host #btn-mobile::before {
+:host #btn-activate::before {
   margin-right: 8px;
 }
 
-:host #btn-activate::after,
-:host #btn-mobile::after {
+:host #btn-activate::after {
   margin-left: 8px;
 }
 
-:host #btn-activate:hover,
-:host #btn-mobile:hover {
+:host #btn-activate:hover {
   background-color: var(--terminal-white);
   color: #000;
 }
 
-:host #btn-activate:hover::before,
-:host #btn-mobile:hover::before {
+:host #btn-activate:hover::before {
   content: '🞂';
   opacity: 1;
 }
 
-:host #btn-activate:hover::after,
-:host #btn-mobile:hover::after {
+:host #btn-activate:hover::after {
   content: '🞀';
   opacity: 1;
 }
-:host #btn-activate:disabled,
-:host #btn-mobile:disabled {
+:host #btn-activate:disabled {
   cursor: wait;
   animation: none;
   opacity: 0.7;
@@ -283,8 +301,7 @@
     font-size: 24px;
   }
 
-  :host #btn-activate,
-  :host #btn-mobile {
+  :host #btn-activate {
     font-size: 28px;
   }
 }
@@ -300,8 +317,7 @@
     padding: 5px 10px;
   }
 
-  :host #btn-activate,
-  :host #btn-mobile {
+  :host #btn-activate {
     font-size: 22px;
     padding: 10px 20px;
   }

--- a/src/app.component.html
+++ b/src/app.component.html
@@ -1,5 +1,19 @@
 <!-- Veiled State -->
 <div #veiledContainer id="veiled-container" [class.activating]="isActivating()">
+  <!-- Background Animation -->
+  <div class="background-formulas">
+    @for (formula of backgroundFormulas(); track formula.id) {
+      <span
+        class="math-formula"
+        [style.top]="formula.top"
+        [style.left]="formula.left"
+        [class.visible]="formula.isVisible()"
+        [class.fading-out]="formula.isFadingOut()">
+        {{ formula.typedText }}
+      </span>
+    }
+  </div>
+
   <div #titleVeiled class="title-veiled">&nbsp;</div>
   <div class="badge-veiled">Photographer ⦁ Designer ⦁ Producer ⦁ Editor ⦁ Colorist ⦁ etc </div>
   <span #kaoVeiled id="kao-veiled" class="kao" [class.spinning]="isActivating()">⛧</span>
@@ -7,11 +21,8 @@
     @if (isActivating()) {
       CONNECTING...
     } @else {
-      PC Version
+      🞂 View Portfolio 🞀
     }
-  </button>
-  <button id="btn-mobile" type="button">
-    Mobile Version
   </button>
 </div>
 

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -8,6 +8,7 @@ import {
   inject,
   ChangeDetectionStrategy,
   signal,
+  WritableSignal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { GuideService } from './guide.service';
@@ -26,6 +27,17 @@ interface CardData {
     scale: number;
     position: { x: number; y: number; z: number };
   };
+}
+
+// Interface for the background formula effect
+interface Formula {
+  id: number;
+  fullText: string;
+  typedText: string;
+  top: string;
+  left: string;
+  isVisible: WritableSignal<boolean>;
+  isFadingOut: WritableSignal<boolean>;
 }
 
 @Component({
@@ -49,6 +61,24 @@ export class AppComponent implements AfterViewInit, OnDestroy {
   fpsEl = viewChild<ElementRef<HTMLDivElement>>('fps');
 
   isActivating = signal(false);
+
+  // --- Background Animation Properties ---
+  backgroundFormulas = signal<Formula[]>([]);
+  private formulaIdCounter = 0;
+  private readonly GRID_ROWS = 20;
+  private readonly GRID_COLS = 30;
+  private occupiedCells = new Set<string>();
+  private backgroundInterval: any;
+  private readonly FADE_DURATION = 1500; // ms, must match CSS transition
+
+  private readonly FORMULA_EXAMPLES = [
+    'E = mc²', '∇·E = ρ/ε₀', '∇·B = 0', '∇×E = -∂B/∂t', '∇×B = μ₀(J+ε₀∂E/∂t)',
+    '∫B·ds = μ₀I', 'Φ_B = ∫B·dA', 'F = q(E + v×B)', 'U = -p·E', 'C = Q/V',
+    'R = V/I', 'P = IV', 'L = Φ_B/I', '∮E·dl = -dΦ_B/dt', 'x(t) = Acos(ωt+φ)',
+    'λ = h/p', 'ΔxΔp ≥ ħ/2', 'HΨ = EΨ', 'PV = nRT', 'dS ≥ 0',
+    'F = G(m₁m₂/r²)', 'a² + b² = c²', 'sin(α±β) = sinαcosβ±cosαsinβ',
+    'e^(iπ) + 1 = 0', '1+1=2'
+  ];
 
   private readonly CARD_DATA: CardData[] = [
     {
@@ -232,6 +262,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
 
   ngAfterViewInit(): void {
     this.boot();
+    this.startBackgroundAnimation();
   }
 
   ngOnDestroy(): void {
@@ -239,6 +270,79 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     if (this.threeState._ro) this.threeState._ro.disconnect();
     if (this.threeState._raf) cancelAnimationFrame(this.threeState._raf);
     this._listeners.forEach(unlisten => unlisten());
+    clearInterval(this.backgroundInterval);
+  }
+
+  // --- Background Animation Logic ---
+  private startBackgroundAnimation(): void {
+    this.backgroundInterval = setInterval(() => {
+      if (this.backgroundFormulas().length < 50) {
+        this.addAndAnimateNewFormula();
+      }
+    }, 200);
+  }
+
+  private findAvailableCell(): { row: number; col: number } | null {
+    const deadZone = {
+      rowStart: 5, rowEnd: 15,
+      colStart: 8, colEnd: 22,
+    };
+
+    const availableCells: { row: number; col: number }[] = [];
+    for (let r = 0; r < this.GRID_ROWS; r++) {
+      for (let c = 0; c < this.GRID_COLS; c++) {
+        const isOccupied = this.occupiedCells.has(`${r}:${c}`);
+        const isInDeadZone =
+          r >= deadZone.rowStart &&
+          r <= deadZone.rowEnd &&
+          c >= deadZone.colStart &&
+          c <= deadZone.colEnd;
+        if (!isOccupied && !isInDeadZone) {
+          availableCells.push({ row: r, col: c });
+        }
+      }
+    }
+
+    if (availableCells.length === 0) return null;
+    return availableCells[Math.floor(Math.random() * availableCells.length)];
+  }
+
+  private async addAndAnimateNewFormula(): Promise<void> {
+    const cell = this.findAvailableCell();
+    if (!cell) return;
+
+    const cellKey = `${cell.row}:${cell.col}`;
+    this.occupiedCells.add(cellKey);
+
+    const newFormula: Formula = {
+      id: this.formulaIdCounter++,
+      fullText:
+        this.FORMULA_EXAMPLES[Math.floor(Math.random() * this.FORMULA_EXAMPLES.length)],
+      typedText: '',
+      top: `${(cell.row / this.GRID_ROWS) * 100}%`,
+      left: `${(cell.col / this.GRID_COLS) * 100}%`,
+      isVisible: signal(false),
+      isFadingOut: signal(false),
+    };
+
+    this.backgroundFormulas.update((formulas) => [...formulas, newFormula]);
+
+    requestAnimationFrame(() => newFormula.isVisible.set(true));
+
+    const typingSpeed = 50 + Math.random() * 50;
+    for (let i = 0; i < newFormula.fullText.length; i++) {
+      newFormula.typedText += newFormula.fullText[i];
+      await new Promise((res) => setTimeout(res, typingSpeed));
+    }
+
+    newFormula.isFadingOut.set(true);
+
+    setTimeout(() => {
+      this.backgroundFormulas.update((formulas) =>
+        formulas.filter((f) => f.id !== newFormula.id)
+      );
+      this.occupiedCells.delete(cellKey);
+    }, this.FADE_DURATION);
   }
 
   // --- Boot Logic ---


### PR DESCRIPTION
## Summary
- implement background math-formula animation on landing screen
- style formulas overlay with fading typewriter effect
- remove unused mobile button styles

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68c06593452c83258ba53eabe56b349a