### PR TITLE
Add mobile version button with shared styles

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -107,7 +107,8 @@
   font-size: 28px;
 }
 
-:host #btn-activate {
+:host #btn-activate,
+:host #btn-mobile {
   font-family: 'VT323', monospace;
   background: none;
   border: none;
@@ -124,34 +125,42 @@
 }
 
 :host #btn-activate::before,
-:host #btn-activate::after {
+:host #btn-activate::after,
+:host #btn-mobile::before,
+:host #btn-mobile::after {
   content: '';
   opacity: 0;
 }
 
-:host #btn-activate::before {
+:host #btn-activate::before,
+:host #btn-mobile::before {
   margin-right: 8px;
 }
 
-:host #btn-activate::after {
+:host #btn-activate::after,
+:host #btn-mobile::after {
   margin-left: 8px;
 }
 
-:host #btn-activate:hover {
+:host #btn-activate:hover,
+:host #btn-mobile:hover {
   background-color: var(--terminal-white);
   color: #000;
 }
 
-:host #btn-activate:hover::before {
+:host #btn-activate:hover::before,
+:host #btn-mobile:hover::before {
   content: '🞂';
   opacity: 1;
 }
 
-:host #btn-activate:hover::after {
+:host #btn-activate:hover::after,
+:host #btn-mobile:hover::after {
   content: '🞀';
   opacity: 1;
 }
-:host #btn-activate:disabled {
+:host #btn-activate:disabled,
+:host #btn-mobile:disabled {
   cursor: wait;
   animation: none;
   opacity: 0.7;
@@ -301,7 +310,8 @@
     font-size: 24px;
   }
 
-  :host #btn-activate {
+  :host #btn-activate,
+  :host #btn-mobile {
     font-size: 28px;
   }
 }
@@ -317,7 +327,8 @@
     padding: 5px 10px;
   }
 
-  :host #btn-activate {
+  :host #btn-activate,
+  :host #btn-mobile {
     font-size: 22px;
     padding: 10px 20px;
   }

--- a/src/app.component.html
+++ b/src/app.component.html
@@ -24,6 +24,7 @@
       🞂 View Portfolio 🞀
     }
   </button>
+  <button id="btn-mobile" type="button">Mobile Version</button>
 </div>
 
 <!-- Activated State (3D UI) -->


### PR DESCRIPTION
## Summary
- Add a Mobile Version button beside the existing PC/portfolio button
- Share button styling across desktop and mobile controls with responsive tweaks

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c06dc27e14832582019b92febdb601