### PR TITLE
feat: enlarge waiting title and remove cursor

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -77,7 +77,7 @@
   font-family: 'VT323', monospace;
   color: var(--terminal-white);
   font-weight: 400;
-  font-size: 110px;
+  font-size: 150px;
   letter-spacing: 1px;
   line-height: 0.9;
   min-height: 200px;
@@ -96,6 +96,11 @@
   font-size: 0.8em; /* Make it smaller */
   vertical-align: 0.05em; /* Fine-tune vertical alignment */
   animation: blink 1s step-end infinite;
+}
+
+:host .title-veiled.typing-done::after {
+  content: none;
+  animation: none;
 }
 
 :host .badge-veiled {
@@ -302,7 +307,7 @@
 /* --- Responsive adjustments for Veiled State --- */
 @media (max-width: 768px) {
   :host .title-veiled {
-    font-size: 80px;
+    font-size: 110px;
     min-height: 160px;
   }
 
@@ -318,7 +323,7 @@
 
 @media (max-width: 480px) {
   :host .title-veiled {
-    font-size: 54px;
+    font-size: 72px;
     min-height: 110px;
   }
 


### PR DESCRIPTION
## Summary
- enlarge veiled screen title text size for desktop and mobile breakpoints
- hide the blinking cursor once typing effect completes

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68c07101f2608325b2836ee041e08263