### PR TITLE
fix: ensure witness card height measurement

### DIFF
--- a/src/components/witness-card/witness-card.component.ts
+++ b/src/components/witness-card/witness-card.component.ts
@@ -31,6 +31,8 @@ export class WitnessCardComponent {
     const cardEl = this.createWitnessCardEl();
     const bodyEl = this.renderer2.createElement('div');
     this.renderer2.addClass(bodyEl, 'body');
+    this.renderer2.setStyle(bodyEl, 'maxHeight', 'none');
+    this.renderer2.setStyle(bodyEl, 'overflow', 'visible');
     cardEl.innerHTML = `<h4>𝐖𝐈𝐓𝐍𝐄𝐒𝐒 ⇌ 𝐒𝐄𝐑𝐕𝐀𝐍𝐓</h4><hr/>`;
     cardEl.appendChild(bodyEl);
     bodyEl.innerHTML = summary;


### PR DESCRIPTION
## Summary
- override card3d body constraints during measurement so witness card height is calculated correctly

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68c17f63e2d0832587e9182dbd52aad4