### PR TITLE
test: add unit tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm install
+      - run: npm test

--- a/src/background.service.spec.ts
+++ b/src/background.service.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { BackgroundService } from './background.service';
+
+describe('BackgroundService', () => {
+  it('thêm và xóa công thức khỏi nền', async () => {
+    vi.useFakeTimers();
+    (global as any).requestAnimationFrame = (cb: Function) => cb();
+
+    const service = new BackgroundService();
+    (service as any).FORMULA_EXAMPLES = ['ab'];
+    const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const promise = (service as any).addAndAnimateNewFormula();
+
+    expect(service.backgroundFormulas().length).toBe(1);
+
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(service.backgroundFormulas().length).toBe(0);
+
+    mathRandomSpy.mockRestore();
+    vi.useRealTimers();
+  });
+});

--- a/src/components/witness-card/witness-card.component.spec.ts
+++ b/src/components/witness-card/witness-card.component.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { WitnessCardComponent } from './witness-card.component';
+
+class MockRenderer2 {
+  createElement(tag: string) { return document.createElement(tag); }
+  addClass(el: HTMLElement, name: string) { el.classList.add(name); }
+  setStyle(el: HTMLElement, style: string, value: string) { (el.style as any)[style] = value; }
+}
+
+class MockGuideService {
+  getGuidance(id: string) { return Promise.resolve('summary'); }
+}
+
+// Minimal THREE mocks
+class Vector3 {
+  constructor(public x = 0, public y = 0, public z = 0) {}
+  set(x: number, y: number, z: number) { this.x = x; this.y = y; this.z = z; return this; }
+  setFromMatrixColumn(matrix: any, index: number) { this.copy(matrix.columns[index]); return this; }
+  multiplyScalar(s: number) { this.x *= s; this.y *= s; this.z *= s; return this; }
+  add(v: Vector3) { this.x += v.x; this.y += v.y; this.z += v.z; return this; }
+  clone() { return new Vector3(this.x, this.y, this.z); }
+  copy(v: Vector3) { this.x = v.x; this.y = v.y; this.z = v.z; return this; }
+  normalize() { const l = Math.hypot(this.x, this.y, this.z); if (l) { this.x/=l; this.y/=l; this.z/=l; } return this; }
+}
+
+class CSS3DObject {
+  element: HTMLElement;
+  position = new Vector3();
+  rotation = new Vector3();
+  scale = new Vector3(1,1,1);
+  parent: any = null;
+  constructor(el: HTMLElement) { this.element = el; }
+}
+
+(global as any).THREE = { Vector3, CSS3DObject };
+
+const renderer = new MockRenderer2() as any;
+const guide = new MockGuideService() as any;
+const component = new WitnessCardComponent(renderer, guide);
+
+const root = {
+  children: [] as any[],
+  add(obj: any) { this.children.push(obj); obj.parent = this; },
+  remove(obj: any) { this.children = this.children.filter(o => o !== obj); },
+  updateMatrixWorld() {},
+  worldToLocal(v: any) { return v; },
+};
+
+const targetObject = {
+  cardData: { id: 'personal-info-card' },
+  element: { offsetWidth: 100 },
+  scale: new Vector3(1,1,1),
+  rotation: new Vector3(),
+  getWorldPosition(v: any) { v.set(10,0,0); },
+  updateMatrixWorld() {},
+};
+
+const threeState: any = {
+  focused: targetObject,
+  root,
+  camera: { matrixWorld: { columns: [new Vector3(1,0,0), new Vector3(0,1,0), new Vector3(0,0,1)] }, updateMatrixWorld() {} },
+  controls: { update() {} },
+  witnessCard: null,
+};
+
+const typewriter = () => Promise.resolve();
+const tweenVec3 = (obj: any, target: any) => obj.copy(target);
+const spawnKaomojiAt = vi.fn();
+
+(global as any).requestAnimationFrame = (cb: Function) => cb();
+
+describe('WitnessCardComponent', () => {
+  it('hiện card đúng vị trí và ẩn khi hide()', async () => {
+    await component.show(targetObject, threeState, typewriter, tweenVec3, spawnKaomojiAt);
+
+    expect(threeState.witnessCard).toBeTruthy();
+    expect(root.children.length).toBe(1);
+    expect(threeState.witnessCard.position.x).toBeCloseTo(386);
+
+    component.hide(threeState);
+    expect(root.children.length).toBe(0);
+    expect(threeState.witnessCard).toBeNull();
+  });
+});

--- a/src/guide.service.spec.ts
+++ b/src/guide.service.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { GuideService } from './guide.service';
+
+describe('GuideService', () => {
+  it('trả về commentary đúng cho cardId đã biết', async () => {
+    const service = new GuideService();
+    const text = await service.getGuidance('personal-info-card');
+    expect(text).toContain('𝐌𝐢𝐧𝐚𝐭𝐨');
+  });
+
+  it('trả về fallback cho cardId không tồn tại', async () => {
+    const service = new GuideService();
+    const text = await service.getGuidance('unknown-card');
+    expect(text).toBe(
+      "No specific commentary available for this item. It appears to be a standard portfolio entry within the subject's collection."
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- cover GuideService mapping and BackgroundService formula lifecycle
- test WitnessCardComponent show/hide behaviour and relative position
- add CI workflow running `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e14724b88325b3762b95cf4b5763