### PR TITLE
feat: add Win98 nav buttons to mobile HUD

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -58,6 +58,9 @@
     .hud .brand { position:absolute; top:12px; left:16px; font-family: ui-monospace, Menlo, monospace; font-size:12px; letter-spacing:2px; text-transform:uppercase; color:var(--muted); }
     /* bigtype removed for Mobile */
     .hud .fps { position:absolute; bottom:12px; left:16px; color:var(--muted); font-family: ui-monospace, Menlo, monospace; font-size:12px; }
+    .hud .nav-buttons { position:absolute; top:12px; right:16px; display:flex; gap:8px; pointer-events:auto; }
+    .hud .nav-buttons .win98-btn { background:#c0c0c0; border:2px solid; border-top-color:#fff; border-left-color:#fff; border-bottom-color:#808080; border-right-color:#808080; color:#000; padding:2px 8px; text-decoration:none; font-family:'Tahoma',sans-serif; }
+    .hud .nav-buttons .win98-btn:active { border-top-color:#808080; border-left-color:#808080; border-bottom-color:#fff; border-right-color:#fff; position:relative; top:1px; }
 
     .card3d { width:720px; /* lock card width; avoid viewport scaling */ background:var(--card-bg); border:2px solid var(--border); border-radius:12px; padding:64px 48px; color:var(--ink);
       font-family: 'SF Pro Display', 'SF Pro Text', 'San Francisco', 'Noto Sans', 'Roboto', 'Segoe UI', 'Arial', 'Liberation Sans', 'Helvetica Neue', sans-serif;
@@ -96,8 +99,12 @@
     <div id="stage3d" class="stage3d">
       <div class="hud">
         <div class="brand">AI'S FRIEND PRODUCTION</div>
-        
+
         <div id="fps" class="fps">fps: --</div>
+        <div class="nav-buttons">
+          <a class="win98-btn" href="/index.html">Home</a>
+          <a class="win98-btn" href="/blog/index.html">Blog</a>
+        </div>
       </div>
     </div>
     <div class="footer">© 2025 ⛧<span id="ts"></span></div>


### PR DESCRIPTION
## Summary
- add Home and Blog navigation buttons to mobile HUD
- style navigation buttons with Win98 aesthetic and top-right positioning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7c6c45fc88325b3503e653a3d219c