### PR TITLE
refactor: use theme vars for nav buttons

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -59,8 +59,26 @@
     /* bigtype removed for Mobile */
     .hud .fps { position:absolute; bottom:12px; left:16px; color:var(--muted); font-family: ui-monospace, Menlo, monospace; font-size:12px; }
     .hud .nav-buttons { position:absolute; top:12px; right:16px; display:flex; gap:8px; pointer-events:auto; }
-    .hud .nav-buttons .win98-btn { background:#c0c0c0; border:2px solid; border-top-color:#fff; border-left-color:#fff; border-bottom-color:#808080; border-right-color:#808080; color:#000; padding:2px 8px; text-decoration:none; font-family:'Tahoma',sans-serif; }
-    .hud .nav-buttons .win98-btn:active { border-top-color:#808080; border-left-color:#808080; border-bottom-color:#fff; border-right-color:#fff; position:relative; top:1px; }
+    .hud .nav-buttons .win98-btn {
+      background: var(--card-bg, var(--card));
+      border: 2px solid var(--border);
+      border-top-color: var(--border-strong, var(--border));
+      border-left-color: var(--border-strong, var(--border));
+      border-bottom-color: var(--border);
+      border-right-color: var(--border);
+      color: var(--ink);
+      padding: 2px 8px;
+      text-decoration: none;
+      font-family: 'Tahoma', sans-serif;
+    }
+    .hud .nav-buttons .win98-btn:active {
+      border-top-color: var(--border);
+      border-left-color: var(--border);
+      border-bottom-color: var(--border-strong, var(--border));
+      border-right-color: var(--border-strong, var(--border));
+      position: relative;
+      top: 1px;
+    }
 
     .card3d { width:720px; /* lock card width; avoid viewport scaling */ background:var(--card-bg); border:2px solid var(--border); border-radius:12px; padding:64px 48px; color:var(--ink);
       font-family: 'SF Pro Display', 'SF Pro Text', 'San Francisco', 'Noto Sans', 'Roboto', 'Segoe UI', 'Arial', 'Liberation Sans', 'Helvetica Neue', sans-serif;

--- a/src/app.component.css
+++ b/src/app.component.css
@@ -203,8 +203,26 @@
 :host .hud { position:absolute; inset:0; pointer-events:none; z-index:10; }
 :host .hud .brand { position:absolute; top:12px; left:16px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:12px; letter-spacing:2px; text-transform:uppercase; color:#9aa4b2; }
 :host .nav-buttons { position:absolute; top:12px; right:16px; display:flex; gap:8px; pointer-events:auto; }
-:host .win98-btn { background:#c0c0c0; border:2px solid; border-top-color:#fff; border-left-color:#fff; border-bottom-color:#808080; border-right-color:#808080; color:#000; padding:2px 8px; text-decoration:none; font-family:'Tahoma',sans-serif; }
-:host .win98-btn:active { border-top-color:#808080; border-left-color:#808080; border-bottom-color:#fff; border-right-color:#fff; position:relative; top:1px; }
+:host .win98-btn {
+  background: var(--card-bg, var(--card));
+  border: 2px solid var(--border);
+  border-top-color: var(--border-strong, var(--border));
+  border-left-color: var(--border-strong, var(--border));
+  border-bottom-color: var(--border);
+  border-right-color: var(--border);
+  color: var(--ink);
+  padding: 2px 8px;
+  text-decoration: none;
+  font-family: 'Tahoma', sans-serif;
+}
+:host .win98-btn:active {
+  border-top-color: var(--border);
+  border-left-color: var(--border);
+  border-bottom-color: var(--border-strong, var(--border));
+  border-right-color: var(--border-strong, var(--border));
+  position: relative;
+  top: 1px;
+}
 :host #fps { position: absolute; bottom: 12px; left: 16px; color: #9aa4b8; font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
 
 /* CSS cards used by CSS3DRenderer */


### PR DESCRIPTION
## Summary
- unify Win98 button colors with global theme variables
- mirror style changes in `mobile.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7cf5951ac8325958f368b19d731e6