### PR TITLE
style: update win98 button border color

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -63,9 +63,9 @@
     .hud .nav-buttons { position:absolute; top:12px; right:16px; display:flex; gap:8px; pointer-events:auto; }
     .hud .nav-buttons .win98-btn {
       background: var(--card-bg, var(--card));
-      border: 2px solid var(--border);
-      border-top-color: var(--border-strong, var(--border));
-      border-left-color: var(--border-strong, var(--border));
+      border: 2px solid var(--terminal-green);
+      border-top-color: var(--terminal-green);
+      border-left-color: var(--terminal-green);
       border-bottom-color: var(--border);
       border-right-color: var(--border);
       color: var(--ink);

--- a/src/app.component.css
+++ b/src/app.component.css
@@ -205,9 +205,9 @@
 :host .nav-buttons { position:absolute; top:12px; right:16px; display:flex; gap:8px; pointer-events:auto; }
 :host .win98-btn {
   background: var(--card-bg, var(--card));
-  border: 2px solid var(--border);
-  border-top-color: var(--border-strong, var(--border));
-  border-left-color: var(--border-strong, var(--border));
+  border: 2px solid var(--terminal-green);
+  border-top-color: var(--terminal-green);
+  border-left-color: var(--terminal-green);
   border-bottom-color: var(--border);
   border-right-color: var(--border);
   color: var(--ink);


### PR DESCRIPTION
## Summary
- use terminal green border for Win98 button in Angular app component
- match mobile Win98 button border styles with terminal green

## Testing
- `npm test` *(fails: command not found)*
- `apt-get install -y nodejs npm` *(attempted, installation incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f1ad6608832595559f480bee039b