### PR TITLE
Adjust veiled title alignment

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -80,6 +80,8 @@
   font-size: 125px;
   letter-spacing: 1px;
   line-height: 0.9;
+  display: flex;
+  align-items: flex-end;
   min-height: 200px;
   text-transform: uppercase;
 }
@@ -334,6 +336,8 @@
 @media (max-width: 768px) {
   :host .title-veiled {
     font-size: 72px;
+    display: flex;
+    align-items: flex-end;
     min-height: 160px;
   }
 
@@ -350,6 +354,8 @@
 @media (max-width: 480px) {
   :host .title-veiled {
     font-size: 42px;
+    display: flex;
+    align-items: flex-end;
     min-height: 110px;
   }
 


### PR DESCRIPTION
## Summary
- align the veiled title with flexbox so the badge can sit closer while keeping its position stable
- mirror the flex alignment tweaks in the 768px and 480px responsive breakpoints that define a min-height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8edf181ec8325913d280aa5df966d