### PR TITLE
feat: add blog landing page

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -24,7 +24,8 @@
               "sitemap.xml",
               "src/assets",
               "styles.css",
-              "mobile.html"
+              "mobile.html",
+              "blog"
             ]
           },
           "configurations": {

--- a/blog/blog.css
+++ b/blog/blog.css
@@ -1,0 +1,316 @@
+:root {
+  --bg:#060606;
+  --card:rgba(17, 17, 23, 0.78);
+  --card-bg:var(--card);
+  --ink:#e6edf3;
+  --muted:#9aa4b2;
+  --accent:#7dd3fc;
+  --ok:#22c55e;
+  --warn:#f59e0b;
+  --hot:#f43f5e;
+  --border:#1f2937;
+  --border-strong:#334155;
+  --btn-bg:#121212;
+  --bgx:50%;
+  --bgy:45%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--ink);
+  font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu;
+}
+
+body {
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.stage3d {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  overflow: hidden;
+  background: radial-gradient(1200px 600px at var(--bgx) var(--bgy), #080808 0%, #060606 60%, #040404 100%);
+  touch-action: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.stage3d canvas {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.stage3d .css3d {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.hud {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.hud .brand {
+  position: absolute;
+  top: 12px;
+  left: 16px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.nav-buttons {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  display: flex;
+  gap: 8px;
+  pointer-events: auto;
+}
+
+.win98-btn {
+  background: var(--card-bg);
+  border: 2px solid var(--ok);
+  border-top-color: var(--ok);
+  border-left-color: var(--ok);
+  border-bottom-color: var(--border);
+  border-right-color: var(--border);
+  color: var(--ink);
+  padding: 2px 8px;
+  text-decoration: none;
+  font-family: 'Tahoma', sans-serif;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+}
+
+.win98-btn:active {
+  border-top-color: var(--border);
+  border-left-color: var(--border);
+  border-bottom-color: var(--border-strong);
+  border-right-color: var(--border-strong);
+  position: relative;
+  top: 1px;
+}
+
+.win98-btn.active,
+.win98-btn[aria-current="page"] {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: 0 0 12px rgba(125, 211, 252, 0.45);
+}
+
+.fps {
+  position: absolute;
+  bottom: 12px;
+  left: 16px;
+  color: var(--muted);
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 12px;
+}
+
+.content {
+  position: relative;
+  z-index: 4;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 120px 32px 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.placeholder-panel {
+  background: rgba(17, 24, 39, 0.68);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 18px;
+  padding: 32px;
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(10px);
+}
+
+.banner-slot {
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.banner-slot span {
+  color: var(--accent);
+}
+
+.main-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 32px;
+}
+
+.article-slot {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.article-slot header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.article-slot h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw + 1rem, 3.25rem);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.article-slot p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.article-slot .mono {
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 0.85rem;
+  letter-spacing: 0.28em;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  opacity: 0.8;
+  letter-spacing: 0.32em;
+}
+
+.interstitial-slot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  min-height: 140px;
+  border-radius: 16px;
+  background: rgba(125, 211, 252, 0.1);
+  border: 1px dashed rgba(125, 211, 252, 0.6);
+  color: var(--accent);
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.sidebar-slot {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 320px;
+  position: sticky;
+  top: 120px;
+}
+
+.footer {
+  margin: 0;
+  padding: 16px 24px;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: right;
+}
+
+@media (max-width: 1200px) {
+  .content {
+    padding: 112px 24px 88px;
+  }
+}
+
+@media (max-width: 1024px) {
+  .main-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar-slot {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .stage3d {
+    min-height: 100svh;
+  }
+
+  .content {
+    padding: 104px 16px 72px;
+    gap: 24px;
+  }
+
+  .banner-slot {
+    min-height: 140px;
+    font-size: 1.25rem;
+    letter-spacing: 0.2em;
+  }
+
+  .placeholder-panel {
+    padding: 24px;
+    border-radius: 14px;
+  }
+
+  .article-slot {
+    gap: 16px;
+  }
+
+  .interstitial-slot {
+    min-height: 120px;
+    letter-spacing: 0.16em;
+  }
+
+  .hud .brand {
+    font-size: 11px;
+    left: 12px;
+  }
+
+  .nav-buttons {
+    right: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .banner-slot {
+    font-size: 1.1rem;
+    letter-spacing: 0.14em;
+  }
+
+  .article-slot h1 {
+    letter-spacing: 0.12em;
+  }
+
+  .interstitial-slot {
+    font-size: 0.75rem;
+  }
+}

--- a/blog/blog.js
+++ b/blog/blog.js
@@ -1,0 +1,218 @@
+(function(){
+  const stage = document.getElementById('stage3d');
+  if (!stage || !window.THREE) {
+    return;
+  }
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const isMobile = window.matchMedia('(max-width: 768px)');
+  let allowMotion = !prefersReducedMotion.matches;
+
+  const scene = new THREE.Scene();
+  scene.fog = new THREE.FogExp2(0x030406, 0.0009);
+
+  const camera = new THREE.PerspectiveCamera(60, stage.clientWidth / stage.clientHeight, 1, 5000);
+  camera.position.set(0, 0, isMobile.matches ? 900 : 1200);
+
+  const renderer = new THREE.WebGLRenderer({
+    alpha: true,
+    antialias: !isMobile.matches,
+    powerPreference: 'high-performance'
+  });
+  renderer.setPixelRatio(isMobile.matches ? 1 : Math.min(window.devicePixelRatio || 1, 2));
+  renderer.setSize(stage.clientWidth, stage.clientHeight);
+  renderer.domElement.classList.add('webgl-layer');
+  renderer.domElement.style.pointerEvents = 'none';
+  renderer.domElement.setAttribute('aria-hidden', 'true');
+  stage.insertBefore(renderer.domElement, stage.firstChild);
+
+  let cssRenderer = null;
+  let cssScene = null;
+  if (THREE.CSS3DRenderer) {
+    cssScene = new THREE.Scene();
+    cssRenderer = new THREE.CSS3DRenderer();
+    cssRenderer.setSize(stage.clientWidth, stage.clientHeight);
+    cssRenderer.domElement.classList.add('css3d');
+    cssRenderer.domElement.style.pointerEvents = 'none';
+    cssRenderer.domElement.setAttribute('aria-hidden', 'true');
+
+    const placeholder = stage.querySelector('.css3d');
+    if (placeholder && placeholder !== cssRenderer.domElement) {
+      stage.replaceChild(cssRenderer.domElement, placeholder);
+    } else {
+      stage.appendChild(cssRenderer.domElement);
+    }
+  }
+
+  const particleTotal = prefersReducedMotion.matches ? 280 : (isMobile.matches ? 900 : 1600);
+  const geometry = new THREE.BufferGeometry();
+  const positions = new Float32Array(particleTotal * 3);
+  const basePositions = new Float32Array(particleTotal * 3);
+  const driftSpeeds = new Float32Array(particleTotal);
+
+  for (let i = 0; i < particleTotal; i++) {
+    const i3 = i * 3;
+    const radius = 280 + Math.pow(Math.random(), 0.55) * 1400;
+    const theta = Math.random() * Math.PI * 2;
+    const phi = Math.acos(Math.random() * 2 - 1);
+    const sinPhi = Math.sin(phi);
+
+    const x = radius * sinPhi * Math.cos(theta);
+    const y = radius * Math.cos(phi);
+    const z = radius * sinPhi * Math.sin(theta);
+
+    positions[i3] = x;
+    positions[i3 + 1] = y;
+    positions[i3 + 2] = z;
+
+    basePositions[i3] = x;
+    basePositions[i3 + 1] = y;
+    basePositions[i3 + 2] = z;
+
+    driftSpeeds[i] = 0.3 + Math.random() * 0.8;
+  }
+
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+
+  const material = new THREE.PointsMaterial({
+    color: 0x7dd3fc,
+    size: isMobile.matches ? 2.6 : 3.4,
+    transparent: true,
+    opacity: 0.85,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending
+  });
+
+  const particles = new THREE.Points(geometry, material);
+  scene.add(particles);
+
+  const ambient = new THREE.AmbientLight(0xffffff, 0.12);
+  scene.add(ambient);
+
+  const targetParallax = new THREE.Vector2(0, 0);
+  const currentParallax = new THREE.Vector2(0, 0);
+
+  function updateGradient() {
+    const x = (currentParallax.x * 12) + 50;
+    const y = 45 - (currentParallax.y * 10);
+    stage.style.setProperty('--bgx', `${x.toFixed(2)}%`);
+    stage.style.setProperty('--bgy', `${y.toFixed(2)}%`);
+  }
+
+  const pointerHandler = (event) => {
+    const rect = stage.getBoundingClientRect();
+    const x = (event.clientX - rect.left) / rect.width;
+    const y = (event.clientY - rect.top) / rect.height;
+    targetParallax.set(x * 2 - 1, (y * 2 - 1) * -1);
+  };
+
+  const leaveHandler = () => {
+    targetParallax.set(0, 0);
+  };
+
+  stage.addEventListener('pointermove', pointerHandler);
+  stage.addEventListener('pointerleave', leaveHandler);
+  stage.addEventListener('touchmove', (event) => {
+    if (!event.touches || event.touches.length === 0) return;
+    const rect = stage.getBoundingClientRect();
+    const touch = event.touches[0];
+    const x = (touch.clientX - rect.left) / rect.width;
+    const y = (touch.clientY - rect.top) / rect.height;
+    targetParallax.set(x * 2 - 1, (y * 2 - 1) * -1);
+  }, { passive: true });
+  stage.addEventListener('touchend', leaveHandler);
+  stage.addEventListener('touchcancel', leaveHandler);
+
+  const clock = new THREE.Clock();
+  let elapsed = 0;
+  let frames = 0;
+  let fpsStart = performance.now();
+  const fpsElement = document.getElementById('fps');
+
+  function animate() {
+    const delta = clock.getDelta();
+    elapsed += delta;
+
+    currentParallax.lerp(targetParallax, 0.08);
+    camera.position.x = currentParallax.x * 70;
+    camera.position.y = currentParallax.y * 48;
+    camera.lookAt(0, 0, 0);
+    updateGradient();
+
+    if (allowMotion) {
+      const arr = geometry.attributes.position.array;
+      for (let i = 0; i < particleTotal; i++) {
+        const i3 = i * 3;
+        const speed = driftSpeeds[i];
+        arr[i3] = basePositions[i3] + Math.sin(elapsed * speed * 0.6 + i * 0.12) * 18;
+        arr[i3 + 1] = basePositions[i3 + 1] + Math.cos(elapsed * speed * 0.45 + i * 0.08) * 22;
+        arr[i3 + 2] = basePositions[i3 + 2] + Math.sin(elapsed * speed * 0.5 + i * 0.15) * 18;
+      }
+      geometry.attributes.position.needsUpdate = true;
+      particles.rotation.y += delta * 0.18;
+      particles.rotation.x = Math.sin(elapsed * 0.22) * 0.08;
+    }
+
+    renderer.render(scene, camera);
+    if (cssRenderer && cssScene) {
+      cssRenderer.render(cssScene, camera);
+    }
+
+    frames += 1;
+    const now = performance.now();
+    if (fpsElement && now - fpsStart >= 500) {
+      const fps = Math.round((frames * 1000) / (now - fpsStart));
+      fpsElement.textContent = `fps: ${fps}`;
+      fpsStart = now;
+      frames = 0;
+    }
+
+    requestAnimationFrame(animate);
+  }
+
+  animate();
+
+  const resize = () => {
+    const width = stage.clientWidth;
+    const height = stage.clientHeight;
+    camera.aspect = width / Math.max(height, 1);
+    camera.updateProjectionMatrix();
+    renderer.setSize(width, height);
+    if (cssRenderer) {
+      cssRenderer.setSize(width, height);
+    }
+  };
+
+  window.addEventListener('resize', resize);
+  if (window.ResizeObserver) {
+    const observer = new ResizeObserver(() => resize());
+    observer.observe(stage);
+  }
+
+  const updatePixelRatio = () => {
+    renderer.setPixelRatio(isMobile.matches ? 1 : Math.min(window.devicePixelRatio || 1, 2));
+  };
+
+  const addMediaListener = (mediaQuery, handler) => {
+    if (!mediaQuery) return;
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handler);
+    } else if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(handler);
+    }
+  };
+
+  addMediaListener(isMobile, () => {
+    updatePixelRatio();
+    camera.position.z = isMobile.matches ? 900 : 1200;
+    resize();
+  });
+
+  addMediaListener(prefersReducedMotion, (event) => {
+    allowMotion = !event.matches;
+    if (!allowMotion) {
+      geometry.attributes.position.array.set(basePositions);
+      geometry.attributes.position.needsUpdate = true;
+    }
+  });
+})();

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <style>html,body{background:#060606;color-scheme:dark}</style>
+  <meta name="theme-color" content="#060606">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <title>Minato Makoto | Blog</title>
+  <meta name="description" content="Nhật ký sáng tạo và nghiên cứu của Minato Makoto về video, thiết kế và công nghệ.">
+  <link rel="icon" type="image/x-icon" href="../src/assets/20250910_091520.ico">
+  <link rel="canonical" href="https://minato-makoto.github.io/blog/">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://minato-makoto.github.io/blog/">
+  <meta property="og:title" content="Minato Makoto | Blog">
+  <meta property="og:description" content="Nhật ký sáng tạo và nghiên cứu của Minato Makoto về video, thiết kế và công nghệ.">
+  <meta property="og:image" content="https://minato-makoto.github.io/src/assets/images/og-preview.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Minato Makoto | Blog">
+  <meta name="twitter:description" content="Nhật ký sáng tạo và nghiên cứu của Minato Makoto về video, thiết kế và công nghệ.">
+  <meta name="twitter:image" content="https://minato-makoto.github.io/src/assets/images/og-preview.jpg">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./blog.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/renderers/CSS3DRenderer.js"></script>
+  <script defer src="./blog.js"></script>
+</head>
+<body class="text-gray-200 font-sans antialiased">
+  <div id="stage3d" class="stage3d">
+    <div class="css3d" aria-hidden="true"></div>
+    <div class="hud">
+      <div class="brand">AI's Friend Production</div>
+      <div class="nav-buttons">
+        <a href="/index.html" class="win98-btn btn-primary">Home</a>
+        <a href="/blog/index.html" class="win98-btn btn-primary active" aria-current="page">Blog</a>
+      </div>
+      <div id="fps" class="fps">fps: --</div>
+    </div>
+
+    <div class="content" role="main">
+      <div class="banner-slot placeholder-panel" role="img" aria-label="Vùng banner blog">
+        <span>Blog Banner Placeholder</span>
+      </div>
+
+      <div class="main-layout">
+        <article class="article-slot placeholder-panel">
+          <header>
+            <p class="mono eyebrow">Changelog &amp; Insights</p>
+            <h1>Blog Hub đang được kích hoạt</h1>
+          </header>
+          <p>
+            Đây là không gian để Minato ghi lại quy trình sáng tạo, hậu trường sản xuất và những thử nghiệm công nghệ.
+            Các bài viết sẽ xuất hiện tại đây ngay khi hoàn tất hiệu chỉnh nội dung.
+          </p>
+          <div class="interstitial-slot" aria-hidden="true">Interstitial Placeholder</div>
+          <p>
+            Trong lúc chờ đợi, bạn có thể quay lại trang chủ để khám phá portfolio 3D tương tác
+            hoặc theo dõi các kênh mạng xã hội để cập nhật dự án mới nhất.
+          </p>
+        </article>
+
+        <aside class="sidebar-slot placeholder-panel" aria-label="Vùng đề xuất bên cạnh">
+          <p class="mono eyebrow">Sidebar Placeholder</p>
+          <p>Không gian cho danh mục bài viết, gợi ý hoặc CTA phụ trợ.</p>
+        </aside>
+      </div>
+    </div>
+  </div>
+  <footer class="footer">© 2025 ⛧</footer>
+</body>
+</html>

--- a/mobile.html
+++ b/mobile.html
@@ -73,6 +73,12 @@
       text-decoration: none;
       font-family: 'Tahoma', sans-serif;
     }
+    .hud .nav-buttons .win98-btn.active,
+    .hud .nav-buttons .win98-btn[aria-current="page"] {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 12px rgba(125, 211, 252, 0.45);
+    }
     .hud .nav-buttons .win98-btn:active {
       border-top-color: var(--border);
       border-left-color: var(--border);
@@ -122,7 +128,7 @@
 
         <div id="fps" class="fps">fps: --</div>
         <div class="nav-buttons">
-          <a class="win98-btn btn-primary" href="/index.html">Home</a>
+          <a class="win98-btn btn-primary active" href="/index.html" aria-current="page">Home</a>
           <a class="win98-btn btn-primary" href="/blog/index.html">Blog</a>
         </div>
       </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,4 +5,9 @@
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://minato-makoto.github.io/blog/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/src/app.component.css
+++ b/src/app.component.css
@@ -215,6 +215,12 @@
   text-decoration: none;
   font-family: 'Tahoma', sans-serif;
 }
+:host .win98-btn.active,
+:host .win98-btn[aria-current="page"] {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: 0 0 12px rgba(125, 211, 252, 0.45);
+}
 :host .win98-btn:active {
   border-top-color: var(--border);
   border-left-color: var(--border);

--- a/src/app.component.html
+++ b/src/app.component.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="nav-buttons">
-    <a href="/index.html" class="win98-btn btn-primary">Home</a>
+    <a href="/index.html" class="win98-btn btn-primary active" aria-current="page">Home</a>
     <a href="/blog/index.html" class="win98-btn btn-primary">Blog</a>
   </div>
 
@@ -44,7 +44,7 @@
     <div class="hud">
       <div class="brand">AI's Friend Production</div>
       <div class="nav-buttons">
-        <a href="/index.html" class="win98-btn btn-primary">Home</a>
+        <a href="/index.html" class="win98-btn btn-primary active" aria-current="page">Home</a>
         <a href="/blog/index.html" class="win98-btn btn-primary">Blog</a>
       </div>
       <div #fps id="fps" class="fps">fps: --</div>


### PR DESCRIPTION
## Summary
- introduce a static `/blog` entry point that reuses the 3D stage and HUD layout with dedicated banner, interstitial, and sidebar placeholders
- style the blog hub and drive a responsive three.js particle scene with respect for motion and mobile constraints
- highlight the active navigation state across desktop/mobile shells and register the blog folder for builds and the sitemap

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99994bee08325bba4da10480b21c0