### PR TITLE
fix: restore touch scrolling on blog stage

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -48,7 +48,7 @@ a:hover {
   min-height: 100vh;
   overflow: hidden;
   background: radial-gradient(1200px 600px at var(--bgx) var(--bgy), #080808 0%, #060606 60%, #040404 100%);
-  touch-action: none;
+  touch-action: pan-y;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;


### PR DESCRIPTION
## Summary
- allow the blog stage container to permit vertical scrolling on touch devices by switching touch-action to pan-y

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c99f9537a08325920e86c596f000ea