### PR TITLE
Remove nav active styling across site

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -118,13 +118,6 @@ a:hover {
   top: 1px;
 }
 
-.win98-btn.active,
-.win98-btn[aria-current="page"] {
-  border-color: var(--accent);
-  color: var(--accent);
-  box-shadow: 0 0 12px rgba(125, 211, 252, 0.45);
-}
-
 .fps {
   position: absolute;
   bottom: 12px;

--- a/blog/index.html
+++ b/blog/index.html
@@ -39,7 +39,7 @@
       <div class="brand">AI's Friend Production</div>
       <div class="nav-buttons">
         <a href="/index.html" class="win98-btn btn-primary">Home</a>
-        <a href="/blog/index.html" class="win98-btn btn-primary active" aria-current="page">Blog</a>
+        <a href="/blog/index.html" class="win98-btn btn-primary">Blog</a>
       </div>
       <div id="fps" class="fps">fps: --</div>
     </div>

--- a/mobile.html
+++ b/mobile.html
@@ -73,12 +73,6 @@
       text-decoration: none;
       font-family: 'Tahoma', sans-serif;
     }
-    .hud .nav-buttons .win98-btn.active,
-    .hud .nav-buttons .win98-btn[aria-current="page"] {
-      border-color: var(--accent);
-      color: var(--accent);
-      box-shadow: 0 0 12px rgba(125, 211, 252, 0.45);
-    }
     .hud .nav-buttons .win98-btn:active {
       border-top-color: var(--border);
       border-left-color: var(--border);
@@ -128,7 +122,7 @@
 
         <div id="fps" class="fps">fps: --</div>
         <div class="nav-buttons">
-          <a class="win98-btn btn-primary active" href="/index.html" aria-current="page">Home</a>
+          <a class="win98-btn btn-primary" href="/index.html">Home</a>
           <a class="win98-btn btn-primary" href="/blog/index.html">Blog</a>
         </div>
       </div>

--- a/src/app.component.css
+++ b/src/app.component.css
@@ -215,12 +215,6 @@
   text-decoration: none;
   font-family: 'Tahoma', sans-serif;
 }
-:host .win98-btn.active,
-:host .win98-btn[aria-current="page"] {
-  border-color: var(--accent);
-  color: var(--accent);
-  box-shadow: 0 0 12px rgba(125, 211, 252, 0.45);
-}
 :host .win98-btn:active {
   border-top-color: var(--border);
   border-left-color: var(--border);

--- a/src/app.component.html
+++ b/src/app.component.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="nav-buttons">
-    <a href="/index.html" class="win98-btn btn-primary active" aria-current="page">Home</a>
+    <a href="/index.html" class="win98-btn btn-primary">Home</a>
     <a href="/blog/index.html" class="win98-btn btn-primary">Blog</a>
   </div>
 
@@ -44,7 +44,7 @@
     <div class="hud">
       <div class="brand">AI's Friend Production</div>
       <div class="nav-buttons">
-        <a href="/index.html" class="win98-btn btn-primary active" aria-current="page">Home</a>
+        <a href="/index.html" class="win98-btn btn-primary">Home</a>
         <a href="/blog/index.html" class="win98-btn btn-primary">Blog</a>
       </div>
       <div #fps id="fps" class="fps">fps: --</div>


### PR DESCRIPTION
## Summary
- remove the `active` classes and `aria-current` attributes from the nav buttons in the Angular app, mobile shell, and blog page so both links share the same styling
- delete the special `.win98-btn.active`/`[aria-current="page"]` highlight rules in the Angular, mobile, and blog stylesheets to prevent reintroducing the visual distinction

## Testing
- not run (HTML/CSS changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c9a385a1988325b2858baea5e3b233