### PR TITLE
refactor: centralize html escaping

### DIFF
--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -15,6 +15,7 @@ import { BackgroundService } from './background.service';
 import { WitnessCardComponent } from './components/witness-card/witness-card.component';
 import { CardListComponent } from './components/card-list/card-list.component';
 import { Stage3dComponent } from './components/stage3d/stage3d.component';
+import { escapeHtml } from './utils/escape';
 
 // Make THREE available in the component context, as it's loaded from a script tag.
 declare const THREE: any;
@@ -190,31 +191,30 @@ export class AppComponent implements AfterViewInit, OnDestroy {
   }
 
   // --- Utilities ---
-  private esc(s: any): string { return String(s).replace(/[&<>"']/g, m => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;" }[m as keyof typeof m]!)); }
-  
   private typewriter(element: HTMLElement, text: string, speed = 24): Promise<void> {
+    const sanitized = escapeHtml(text).replace(/&lt;br\s*\/?&gt;/gi, '<br>');
     return new Promise(resolve => {
         let i = 0;
         element.innerHTML = '';
         this.renderer2.setStyle(element, 'visibility', 'visible');
         const timer = setInterval(() => {
-          if (i < text.length) {
+          if (i < sanitized.length) {
             // Check for an HTML tag
-            if (text.charAt(i) === '<') {
-              const closingTagIndex = text.indexOf('>', i);
+            if (sanitized.charAt(i) === '<') {
+              const closingTagIndex = sanitized.indexOf('>', i);
               if (closingTagIndex !== -1) {
                 // It's a tag, append the whole thing
-                const tag = text.substring(i, closingTagIndex + 1);
+                const tag = sanitized.substring(i, closingTagIndex + 1);
                 element.innerHTML += tag;
                 i = closingTagIndex + 1; // Jump index past the tag
               } else {
                 // It's an unclosed '<', just print it
-                element.innerHTML += text.charAt(i);
+                element.innerHTML += sanitized.charAt(i);
                 i++;
               }
             } else {
               // It's a normal character
-              element.innerHTML += text.charAt(i);
+              element.innerHTML += sanitized.charAt(i);
               i++;
             }
           } else {

--- a/src/components/card-list/card-list.component.ts
+++ b/src/components/card-list/card-list.component.ts
@@ -1,4 +1,5 @@
 import { Renderer2 } from '@angular/core';
+import { escapeHtml } from '../../utils/escape';
 
 declare const THREE: any;
 
@@ -18,10 +19,6 @@ export interface CardData {
 export class CardListComponent {
   constructor(private renderer2: Renderer2) {}
 
-  private esc(s: any): string {
-    return String(s).replace(/[&<>"']/g, m => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;" }[m as keyof typeof m]!));
-  }
-
   getVideoCardStyle(): any {
     return { width: '1280px', padding: '32px 16px' };
   }
@@ -31,7 +28,7 @@ export class CardListComponent {
       id: 'personal-info-card',
       title: 'Thông tin cá nhân',
       meta: 'Personal Information',
-      body: `<ul>${["Name: Lương Bảo Huy", "Titles: Video Producer · Graphic Designer · Photographer", "Role: Generalist", "AI Title Generation: Director of Artificial Intelligence"].map(g => `<li>${this.esc(g)}</li>`).join('')}</ul>`,
+      body: `<ul>${["Name: Lương Bảo Huy", "Titles: Video Producer · Graphic Designer · Photographer", "Role: Generalist", "AI Title Generation: Director of Artificial Intelligence"].map(g => `<li>${escapeHtml(g)}</li>`).join('')}</ul>`,
       opts: { noexpand: true, style: { width: '960px' } },
       layout: { scale: 0.6, position: { x: 0, y: 0, z: 0 } }
     },
@@ -62,7 +59,7 @@ export class CardListComponent {
       id: 'external-ids-card',
       title: 'External IDs',
       meta: 'Social Network',
-      body: `<ul>${[{ label: "LinkedIn", handle: "Lương Bảo Huy", url: "https://www.linkedin.com/in/b%E1%BA%A3o-huy-l%C6%B0%C6%A1ng-1653a41a3", status: "OK" }, { label: "Instagram", handle: "@minatomakoto", url: "https://www.instagram.com/minatomakoto", status: "OK" }, { label: "Facebook", handle: "Minato Makoto", url: "https://www.facebook.com/MinatoMakoto/", status: "OK" }, { label: "YouTube", handle: "@minatomakoto", url: "https://www.youtube.com/@minatomakoto", status: "OK" }, { label: "TikTok", handle: "@minatomakoto", url: "https://www.tiktok.com/@minatomakoto", status: "OK" }].map(e => `<li>${this.esc(e.label)}: <a href=\"${e.url}\" target=\"_blank\" rel=\"noopener\">${this.esc(e.handle)}</a></li>`).join('')}</ul>`,
+      body: `<ul>${[{ label: "LinkedIn", handle: "Lương Bảo Huy", url: "https://www.linkedin.com/in/b%E1%BA%A3o-huy-l%C6%B0%C6%A1ng-1653a41a3", status: "OK" }, { label: "Instagram", handle: "@minatomakoto", url: "https://www.instagram.com/minatomakoto", status: "OK" }, { label: "Facebook", handle: "Minato Makoto", url: "https://www.facebook.com/MinatoMakoto/", status: "OK" }, { label: "YouTube", handle: "@minatomakoto", url: "https://www.youtube.com/@minatomakoto", status: "OK" }, { label: "TikTok", handle: "@minatomakoto", url: "https://www.tiktok.com/@minatomakoto", status: "OK" }].map(e => `<li>${escapeHtml(e.label)}: <a href=\"${e.url}\" target=\"_blank\" rel=\"noopener\">${escapeHtml(e.handle)}</a></li>`).join('')}</ul>`,
       layout: { scale: 0.25, position: { x: 50, y: 100, z: 0 } }
     },
     {
@@ -155,7 +152,7 @@ export class CardListComponent {
     const el = this.renderer2.createElement('div');
     this.renderer2.addClass(el, 'card3d');
     if (opts.noexpand) this.renderer2.addClass(el, 'noexpand');
-    el.innerHTML = `<h4>${this.esc(title)}</h4>${meta ? `<div class="meta">${this.esc(meta)}</div>` : ''}<div class="body">${body || ''}</div>`;
+    el.innerHTML = `<h4>${escapeHtml(title)}</h4>${meta ? `<div class="meta">${escapeHtml(meta)}</div>` : ''}<div class="body">${body || ''}</div>`;
     if (opts.style) Object.keys(opts.style).forEach(key => this.renderer2.setStyle(el, key, opts.style[key]));
     return el;
   }

--- a/src/utils/escape.ts
+++ b/src/utils/escape.ts
@@ -1,0 +1,13 @@
+const map: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "\"": "&quot;",
+  "'": "&#39;",
+};
+
+const pattern = /[&<>"']/g;
+
+export function escapeHtml(input: string): string {
+  return String(input).replace(pattern, (m) => map[m] ?? m);
+}


### PR DESCRIPTION
## Summary
- add a shared `escapeHtml` utility for consistent HTML entity escaping
- update the card list component to use the shared escape helper when rendering text
- sanitize typewriter output in the app component while still permitting `<br>` tags

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9b0f804c083259d03c130db7259ca