### PR TITLE
Use signals for background formula typing

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -9,7 +9,7 @@
         [style.left]="formula.left"
         [class.visible]="formula.isVisible()"
         [class.fading-out]="formula.isFadingOut()">
-        {{ formula.typedText }}
+        {{ formula.typedText() }}
       </span>
     }
   </div>

--- a/src/background.service.ts
+++ b/src/background.service.ts
@@ -3,7 +3,7 @@ import { Injectable, signal, WritableSignal } from '@angular/core';
 export interface Formula {
   id: number;
   fullText: string;
-  typedText: string;
+  typedText: WritableSignal<string>;
   top: string;
   left: string;
   isVisible: WritableSignal<boolean>;
@@ -78,7 +78,7 @@ export class BackgroundService {
       id: this.formulaIdCounter++,
       fullText:
         this.FORMULA_EXAMPLES[Math.floor(Math.random() * this.FORMULA_EXAMPLES.length)],
-      typedText: '',
+      typedText: signal(''),
       top: `${(cell.row / this.GRID_ROWS) * 100}%`,
       left: `${(cell.col / this.GRID_COLS) * 100}%`,
       isVisible: signal(false),
@@ -91,7 +91,8 @@ export class BackgroundService {
 
     const typingSpeed = 50 + Math.random() * 50;
     for (let i = 0; i < newFormula.fullText.length; i++) {
-      newFormula.typedText += newFormula.fullText[i];
+      const nextChar = newFormula.fullText[i];
+      newFormula.typedText.update((text) => text + nextChar);
       await new Promise((res) => setTimeout(res, typingSpeed));
     }
 


### PR DESCRIPTION
## Summary
- convert the background formula typed text to a WritableSignal and build it with a signal when creating formulas
- update the typing loop to append characters through the signal update API and render the value via signal invocation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca20d504108325a6520b4668d428e5