### PR TITLE
Add leaderboard ad slot placeholder on blog page

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -167,6 +167,49 @@ a:hover {
   color: var(--accent);
 }
 
+.ad-slot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  background: color-mix(in srgb, var(--card-bg, var(--card)) 30%, transparent);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.35);
+  color: var(--muted);
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  box-sizing: border-box;
+}
+
+.ad-slot span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border: 1px dashed color-mix(in srgb, var(--accent) 60%, transparent);
+  border-radius: 12px;
+  color: var(--accent);
+  font-weight: 600;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.ad-leaderboard {
+  width: 728px;
+  height: 90px;
+  max-width: 100%;
+}
+
+@media (max-width: 768px) {
+  .ad-leaderboard {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 728 / 90;
+  }
+}
+
 .main-layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 320px;

--- a/blog/index.html
+++ b/blog/index.html
@@ -48,6 +48,10 @@
         <span>Blog Banner Placeholder</span>
       </div>
 
+      <div class="ad-slot ad-leaderboard" role="img" aria-label="Khe quảng cáo 728x90">
+        <span>GDN 728×90</span>
+      </div>
+
       <div class="main-layout">
         <article class="article-slot placeholder-panel">
           <header>


### PR DESCRIPTION
## Summary
- insert a leaderboard ad placeholder beneath the blog banner on the blog landing page
- style the new ad slot with theme-friendly framing and responsive behaviour in the blog stylesheet

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cae71fb410832580423b571590be79