### PR TITLE
Add sidebar skyscraper ad placeholder

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -270,10 +270,17 @@ a:hover {
 .sidebar-slot {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 16px;
   min-height: 320px;
   position: sticky;
   top: 120px;
+}
+
+.ad-skyscraper {
+  width: 160px;
+  height: 600px;
+  text-align: center;
 }
 
 .footer {

--- a/blog/index.html
+++ b/blog/index.html
@@ -70,8 +70,9 @@
         </article>
 
         <aside class="sidebar-slot placeholder-panel" aria-label="Vùng đề xuất bên cạnh">
-          <p class="mono eyebrow">Sidebar Placeholder</p>
-          <p>Không gian cho danh mục bài viết, gợi ý hoặc CTA phụ trợ.</p>
+          <div class="ad-slot ad-skyscraper" role="img" aria-label="Khe quảng cáo 160x600">
+            <span>GDN 160×600</span>
+          </div>
         </aside>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace the blog sidebar placeholder text with a 160x600 skyscraper ad slot
- center the sidebar container and define dedicated dimensions for the new skyscraper slot

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caea4a3a38832599c8b3452e9e8ce7