### PR TITLE
feat: redesign blog banner with pixel typography

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -153,18 +153,50 @@ a:hover {
 }
 
 .banner-slot {
+  position: relative;
   min-height: 180px;
   display: flex;
   align-items: center;
   justify-content: center;
-  text-transform: uppercase;
-  letter-spacing: 0.28em;
-  font-size: 1.5rem;
-  font-weight: 600;
+  padding: 24px 16px;
+  text-align: center;
 }
 
-.banner-slot span {
-  color: var(--accent);
+.banner-text {
+  position: relative;
+  display: inline-block;
+  font-family: 'VT323', monospace;
+  font-size: clamp(3rem, 12vw, 7rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #fff;
+  line-height: 1;
+  text-shadow: 0 8px 22px rgba(0, 0, 0, 0.55);
+  z-index: 0;
+}
+
+.banner-text::before,
+.banner-text::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  color: color-mix(in srgb, var(--accent) 88%, #1aefb2 12%);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: transform;
+  pointer-events: none;
+}
+
+.banner-text::before {
+  transform: translate3d(12px, 10px, 0);
+  filter: blur(1px);
+  opacity: 0.65;
+  z-index: -2;
+}
+
+.banner-text::after {
+  transform: translate3d(6px, 6px, 0);
+  opacity: 0.85;
+  z-index: -1;
 }
 
 .ad-slot {

--- a/blog/index.html
+++ b/blog/index.html
@@ -44,8 +44,8 @@
     </div>
 
     <div class="content" role="main">
-      <div class="banner-slot placeholder-panel" role="img" aria-label="Vùng banner blog">
-        <span>Blog Banner Placeholder</span>
+      <div class="banner-slot" role="img" aria-label="Vùng banner blog">
+        <span class="banner-text" data-text="MY BLOG">MY BLOG</span>
       </div>
 
       <div class="ad-slot ad-leaderboard" role="img" aria-label="Khe quảng cáo 728x90">


### PR DESCRIPTION
## Summary
- replace the blog banner placeholder with a single banner text element that stores the label via a data attribute
- style the banner with VT323 pixel typography and layered pseudo-elements for a green 3D glow effect
- remove the old placeholder panel treatment so the banner no longer inherits the frosted border/backdrop

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf2ef0ab88325b5969df3dd117224