### PR TITLE
Simplify blog ad placeholders

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -203,35 +203,23 @@ a:hover {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 0 auto;
-  padding: 16px;
-  border-radius: 18px;
-  border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
-  background: color-mix(in srgb, var(--card-bg, var(--card)) 30%, transparent);
-  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.35);
-  color: var(--muted);
-  letter-spacing: 0.24em;
+  margin-inline: auto;
+  margin-block: 12px;
+  padding: 0;
+  color: color-mix(in srgb, var(--accent) 85%, #f8fafc 15%);
+  letter-spacing: 0.28em;
   text-transform: uppercase;
-  box-sizing: border-box;
-}
-
-.ad-slot span {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  border: 1px dashed color-mix(in srgb, var(--accent) 60%, transparent);
-  border-radius: 12px;
-  color: var(--accent);
-  font-weight: 600;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 600;
+  text-align: center;
+  box-sizing: border-box;
 }
 
 .ad-leaderboard {
   width: 728px;
   height: 90px;
   max-width: 100%;
+  margin-inline: auto;
 }
 
 @media (max-width: 768px) {
@@ -313,6 +301,7 @@ a:hover {
   width: 160px;
   height: 600px;
   text-align: center;
+  margin-inline: auto;
 }
 
 .footer {

--- a/blog/index.html
+++ b/blog/index.html
@@ -49,7 +49,7 @@
       </div>
 
       <div class="ad-slot ad-leaderboard" role="img" aria-label="Khe quảng cáo 728x90">
-        <span>GDN 728×90</span>
+        GDN 728×90
       </div>
 
       <div class="main-layout">
@@ -71,7 +71,7 @@
 
         <aside class="sidebar-slot placeholder-panel" aria-label="Vùng đề xuất bên cạnh">
           <div class="ad-slot ad-skyscraper" role="img" aria-label="Khe quảng cáo 160x600">
-            <span>GDN 160×600</span>
+            GDN 160×600
           </div>
         </aside>
       </div>


### PR DESCRIPTION
## Summary
- render the blog ad placeholder copy directly without extra span wrappers
- restyle the shared ad-slot class to drop decorative borders and use the accent palette for emphasis
- center the leaderboard and skyscraper slots with inline margins after the frame removal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf42f315c832599c5e0f4b3267e2a