### PR TITLE
Add Jersey 25 font styling to key headings

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -165,7 +165,7 @@ a:hover {
 .banner-text {
   position: relative;
   display: inline-block;
-  font-family: 'VT323', monospace;
+  font-family: 'Jersey 25', cursive;
   font-size: clamp(3rem, 12vw, 7rem);
   letter-spacing: 0.12em;
   text-transform: uppercase;

--- a/blog/index.html
+++ b/blog/index.html
@@ -25,7 +25,7 @@
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Jersey+25&family=VT323&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./blog.css">
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/renderers/CSS3DRenderer.js"></script>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
   <!-- Google Fonts for Terminal Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Jersey+25&family=VT323&display=swap" rel="stylesheet">
   <style>
     :root { --bg:#060606; --card:#111826; --ink:#e6edf3; --muted:#9aa4b2; --accent:#7dd3fc; --ok:#22c55e; --warn:#f59e0b; --border:#1f2937; --hot:#f43f5e; --btn-bg:#121212; }
     * { box-sizing:border-box; }

--- a/src/app.component.css
+++ b/src/app.component.css
@@ -74,7 +74,7 @@
 }
 
 :host .title-veiled {
-  font-family: 'VT323', monospace;
+  font-family: 'Jersey 25', cursive;
   color: var(--terminal-white);
   font-weight: 400;
   font-size: 125px;


### PR DESCRIPTION
## Summary
- load the Jersey 25 Google font alongside VT323 on the main and blog entry points
- apply the Jersey 25 face to the blog banner text and the veiled welcome title while keeping other VT323 usages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf637ab0083258b8fa3452336fd7d