### PR TITLE
Adjust blog sidebar ad container styling

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -293,6 +293,7 @@ a:hover {
   align-items: center;
   gap: 16px;
   min-height: 320px;
+  padding: 24px 0;
   position: sticky;
   top: 120px;
 }

--- a/blog/index.html
+++ b/blog/index.html
@@ -69,7 +69,7 @@
           </p>
         </article>
 
-        <aside class="sidebar-slot placeholder-panel" aria-label="Vùng đề xuất bên cạnh">
+        <aside class="sidebar-slot" aria-label="Vùng đề xuất bên cạnh">
           <div class="ad-slot ad-skyscraper" role="img" aria-label="Khe quảng cáo 160x600">
             GDN 160×600
           </div>


### PR DESCRIPTION
## Summary
- remove the placeholder-panel styling from the blog sidebar so the ad slot no longer inherits the background card treatment
- add vertical padding to the sidebar container to keep spacing consistent after the placeholder class is removed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf6ea15148325a70fbda37c76090e