### PR TITLE
Add borders to blog ad placeholders

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -206,6 +206,8 @@ a:hover {
   margin-inline: auto;
   margin-block: 12px;
   padding: 0;
+  background: transparent;
+  border: 1px dashed color-mix(in srgb, var(--accent) 55%, transparent);
   color: color-mix(in srgb, var(--accent) 85%, #f8fafc 15%);
   letter-spacing: 0.28em;
   text-transform: uppercase;

--- a/blog/blog.css
+++ b/blog/blog.css
@@ -207,7 +207,7 @@ a:hover {
   margin-block: 12px;
   padding: 0;
   background: transparent;
-  border: 1px dashed color-mix(in srgb, var(--accent) 55%, transparent);
+  outline: 1px dashed color-mix(in srgb, var(--accent) 55%, transparent);
   color: color-mix(in srgb, var(--accent) 85%, #f8fafc 15%);
   letter-spacing: 0.28em;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- add transparent dashed borders to .ad-slot to visualize ad dimensions
- ensure leaderboard and skyscraper placeholders remain fixed-size using border-box

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf7cb640c83259acfb2583bef6ef7