### PR TITLE
Adjust veiled badge spacing

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -12,7 +12,6 @@
   text-align:center;
   min-height:100vh;
   padding:24px;
-  gap:14px;
   transition:opacity .5s ease-out;
   background: #060606;
   position: relative;
@@ -80,7 +79,7 @@
   font-size: 88px;
   letter-spacing: 1px;
   line-height: 0.9;
-  min-height: 200px;
+  min-height: 3lh;
   text-transform: uppercase;
 }
 
@@ -108,8 +107,10 @@
   border: none;
   color: var(--terminal-green); /* Kept green as requested */
   font-family: 'VT323', monospace;
-  padding: 5px 20px;
   font-size: 28px;
+  margin-block-start: clamp(0.6em, 1em, 1.2em);
+  margin-block-end: clamp(0.45em, 0.75em, 1em);
+  padding: 0.35em 1.5em;
 }
 
 :host #btn-activate,
@@ -333,11 +334,14 @@
 @media (max-width: 768px) {
   :host .title-veiled {
     font-size: 74px;
-    min-height: 160px;
+    min-height: 3.1lh;
   }
 
   :host .badge-veiled {
     font-size: 24px;
+    margin-block-start: clamp(0.65em, 0.95em, 1.2em);
+    margin-block-end: clamp(0.5em, 0.75em, 0.95em);
+    padding: 0.4em 1.45em;
   }
 
   :host #btn-activate,
@@ -351,12 +355,14 @@
     font-size: 36px;
     display: flex;
     align-items: flex-end;
-    min-height: 110px;
+    min-height: 3.4lh;
   }
 
   :host .badge-veiled {
     font-size: 18px;
-    padding: 5px 10px;
+    margin-block-start: clamp(0.7em, 1em, 1.3em);
+    margin-block-end: clamp(0.55em, 0.8em, 1.05em);
+    padding: 0.5em 1.3em;
   }
 
   :host #btn-activate,


### PR DESCRIPTION
## Summary
- remove the rigid gap from the veiled container to allow element-specific spacing
- retune the veiled badge spacing with responsive em/clamp-driven margins and padding
- express title minimum heights in lh units across breakpoints for better font scaling

## Testing
- npm test
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68cb035f7394832589070b7268ed17d7