### PR TITLE
Adjust title and badge spacing

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -79,7 +79,8 @@
   font-size: 88px;
   letter-spacing: 1px;
   line-height: 0.9;
-  min-height: 3lh;
+  min-height: 120px;
+  margin-bottom: 16px;
   text-transform: uppercase;
 }
 
@@ -108,8 +109,8 @@
   color: var(--terminal-green); /* Kept green as requested */
   font-family: 'VT323', monospace;
   font-size: 28px;
-  margin-block-start: clamp(0.6em, 1em, 1.2em);
-  margin-block-end: clamp(0.45em, 0.75em, 1em);
+  margin-top: 20px;
+  margin-bottom: 16px;
   padding: 0.35em 1.5em;
 }
 
@@ -334,13 +335,14 @@
 @media (max-width: 768px) {
   :host .title-veiled {
     font-size: 74px;
-    min-height: 3.1lh;
+    min-height: 100px;
+    margin-bottom: 14px;
   }
 
   :host .badge-veiled {
     font-size: 24px;
-    margin-block-start: clamp(0.65em, 0.95em, 1.2em);
-    margin-block-end: clamp(0.5em, 0.75em, 0.95em);
+    margin-top: 18px;
+    margin-bottom: 14px;
     padding: 0.4em 1.45em;
   }
 
@@ -355,13 +357,14 @@
     font-size: 36px;
     display: flex;
     align-items: flex-end;
-    min-height: 3.4lh;
+    min-height: 72px;
+    margin-bottom: 12px;
   }
 
   :host .badge-veiled {
     font-size: 18px;
-    margin-block-start: clamp(0.7em, 1em, 1.3em);
-    margin-block-end: clamp(0.55em, 0.8em, 1.05em);
+    margin-top: 16px;
+    margin-bottom: 12px;
     padding: 0.5em 1.3em;
   }
 


### PR DESCRIPTION
## Summary
- tighten the veiled title spacing using concrete pixel heights and margins across breakpoints
- replace badge vertical clamp margins with explicit pixel values for consistent spacing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0611001c8325b7f7ccf3510a6f36