### PR TITLE
Adjust blog banner layering

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -166,12 +166,12 @@ a:hover {
   position: relative;
   display: inline-block;
   font-family: 'Jersey 25', cursive;
-  font-size: clamp(3rem, 12vw, 7rem);
+  font-size: clamp(3.6rem, 13vw, 8.5rem);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: #fff;
   line-height: 1;
-  text-shadow: 0 8px 22px rgba(0, 0, 0, 0.55);
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.42), 0 14px 34px rgba(0, 0, 0, 0.65);
   z-index: 0;
 }
 
@@ -180,22 +180,23 @@ a:hover {
   content: attr(data-text);
   position: absolute;
   inset: 0;
-  color: color-mix(in srgb, var(--accent) 88%, #1aefb2 12%);
+  color: rgba(255, 255, 255, 0.75);
   transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
   will-change: transform;
   pointer-events: none;
 }
 
 .banner-text::before {
-  transform: translate3d(12px, 10px, 0);
-  filter: blur(1px);
-  opacity: 0.65;
+  transform: translate3d(5px, 4px, 0);
+  filter: blur(0.8px);
+  opacity: 0.55;
   z-index: -2;
 }
 
 .banner-text::after {
-  transform: translate3d(6px, 6px, 0);
-  opacity: 0.85;
+  transform: translate3d(3px, 2px, 0);
+  color: rgba(255, 255, 255, 0.85);
+  opacity: 0.8;
   z-index: -1;
 }
 


### PR DESCRIPTION
## Summary
- enlarge the blog banner title clamp range so the text occupies more space on larger and smaller screens
- restyle banner pseudo-elements with layered white tones and tighter offsets for improved depth and legibility
- refresh text shadows and blur to balance the new layering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb096a2c888325aaa501236100e9e7