### PR TITLE
Enhance veiled title layering and sync typing data

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -73,6 +73,8 @@
 }
 
 :host .title-veiled {
+  position: relative;
+  display: inline-block;
   font-family: 'Jersey 25', cursive;
   color: var(--terminal-white);
   font-weight: 400;
@@ -82,6 +84,33 @@
   min-height: 160px;
   margin-bottom: 8px;
   text-transform: uppercase;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.42), 0 14px 34px rgba(0, 0, 0, 0.65);
+  white-space: pre-line;
+  z-index: 0;
+}
+
+:host .title-veiled::before,
+:host .title-veiled::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  color: var(--terminal-green);
+  pointer-events: none;
+  white-space: inherit;
+  will-change: transform;
+  z-index: -1;
+}
+
+:host .title-veiled::before {
+  transform: translate3d(5px, 4px, 0);
+  filter: blur(0.8px);
+  opacity: 0.55;
+}
+
+:host .title-veiled::after {
+  transform: translate3d(3px, 2px, 0);
+  opacity: 0.8;
+  z-index: -2;
 }
 
 /* Blinking cursor effect */
@@ -89,17 +118,17 @@
   50% { opacity: 0; }
 }
 
-:host .title-veiled::after {
-  content: '▌';
-  position: relative;
-  left: 8px; /* Slightly closer */
+:host .title-cursor {
+  display: inline-block;
+  margin-left: 8px; /* Slightly closer */
   font-size: 0.8em; /* Make it smaller */
   vertical-align: 0.05em; /* Fine-tune vertical alignment */
   animation: blink 1s step-end infinite;
+  pointer-events: none;
 }
 
-:host .title-veiled.typing-done::after {
-  content: none;
+:host .title-veiled.typing-done .title-cursor {
+  display: none;
   animation: none;
 }
 


### PR DESCRIPTION
## Summary
- restyle the veiled title to mimic the blog banner layering with green shadow clones and blinking cursor element
- add synchronized data-text updates so pseudo-element layers follow the typewriter animation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb1d0731508325a50ce417b0758764