### PR TITLE
Adjust blog sidebar layout widths

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -235,7 +235,7 @@ a:hover {
 
 .main-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
+  grid-template-columns: minmax(0, 1fr) 160px;
   gap: 32px;
 }
 
@@ -293,19 +293,20 @@ a:hover {
 .sidebar-slot {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   gap: 16px;
   min-height: 320px;
-  padding: 24px 0;
+  width: 160px;
+  justify-self: end;
   position: sticky;
-  top: 120px;
+  top: 0;
 }
 
 .ad-skyscraper {
   width: 160px;
   height: 600px;
   text-align: center;
-  margin-inline: auto;
+  margin-inline: 0;
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- narrow the blog layout grid to a fixed 160px sidebar so the main changelog column can expand
- update the sidebar slot styling to align the skyscraper ad flush with the right edge and top of the content
- remove automatic centering from the skyscraper ad block for consistent alignment after the width change

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb81dfc8ac8325b43c337f0a7118c3