### PR TITLE
Remove FPS overlay from blog UI

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -122,15 +122,6 @@ a:hover {
   top: 1px;
 }
 
-.fps {
-  position: absolute;
-  bottom: 12px;
-  left: 16px;
-  color: var(--ink);
-  font-family: ui-monospace, Menlo, monospace;
-  font-size: 12px;
-}
-
 .content {
   position: relative;
   z-index: 4;

--- a/blog/blog.js
+++ b/blog/blog.js
@@ -128,9 +128,6 @@
 
   const clock = new THREE.Clock();
   let elapsed = 0;
-  let frames = 0;
-  let fpsStart = performance.now();
-  const fpsElement = document.getElementById('fps');
   const positionAttribute = geometry.getAttribute('position');
   const colorAttribute = geometry.getAttribute('color');
   const staticIntensity = 0.55;
@@ -195,15 +192,6 @@
     renderer.render(scene, camera);
     if (cssRenderer && cssScene) {
       cssRenderer.render(cssScene, camera);
-    }
-
-    frames += 1;
-    const now = performance.now();
-    if (fpsElement && now - fpsStart >= 500) {
-      const fps = Math.round((frames * 1000) / (now - fpsStart));
-      fpsElement.textContent = `fps: ${fps}`;
-      fpsStart = now;
-      frames = 0;
     }
 
     requestAnimationFrame(animate);

--- a/blog/index.html
+++ b/blog/index.html
@@ -40,7 +40,6 @@
         <a href="/index.html" class="win98-btn btn-primary">Home</a>
         <a href="/blog/index.html" class="win98-btn btn-primary">Blog</a>
       </div>
-      <div id="fps" class="fps">fps: --</div>
     </div>
 
     <div class="content" role="main">


### PR DESCRIPTION
## Summary
- remove the FPS indicator markup and associated styles from the blog HUD
- clean up the blog animation script by dropping the unused FPS tracking logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb8552fe7c83258a2c5521bf981686