### PR TITLE
Add terminal green variable to mobile stylesheet

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -21,6 +21,7 @@
       --ok:#22c55e;              /* success */
       --warn:#f59e0b;            /* warning */
       --hot:#f43f5e;             /* danger */
+      --terminal-green:#39FF14;  /* terminal accent */
       --border:#1f2937;          /* base border */
       --border-strong:#334155;   /* elevated border */
       --btn-bg:#121212;


### PR DESCRIPTION
## Summary
- add the missing `--terminal-green` custom property to the mobile theme so the Windows 98 buttons can reuse the terminal accent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb949ce5948325afbe2e8abde4188e