### PR TITLE
Stop escaping apostrophes in escapeHtml

### DIFF
--- a/src/utils/escape.ts
+++ b/src/utils/escape.ts
@@ -3,10 +3,9 @@ const map: Record<string, string> = {
   "<": "&lt;",
   ">": "&gt;",
   "\"": "&quot;",
-  "'": "&#39;",
 };
 
-const pattern = /[&<>"']/g;
+const pattern = /[&<>"]/g;
 
 export function escapeHtml(input: string): string {
   return String(input).replace(pattern, (m) => map[m] ?? m);


### PR DESCRIPTION
## Summary
- update `escapeHtml` so apostrophes are no longer converted to HTML entities, ensuring witness card strings keep literal `'`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb9ead82388325992a9f1a0a333ef6