### PR TITLE
Add Google tag manager snippet to static pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="vi">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7LSEN9HJPK"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-7LSEN9HJPK');
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Minato Makoto | Interactive 3D Portfolio</title>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="vi">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7LSEN9HJPK"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-7LSEN9HJPK');
+  </script>
   <style>html,body{background:#060606;color-scheme:dark}</style>
   <meta name="theme-color" content="#060606">
   <meta name="mobile-web-app-capable" content="yes">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="vi">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7LSEN9HJPK"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-7LSEN9HJPK');
+  </script>
   <style>html,body{background:#060606;color-scheme:dark}</style>
   <meta name="theme-color" content="#060606">
   <meta name="mobile-web-app-capable" content="yes">

--- a/mobile.html
+++ b/mobile.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="vi">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7LSEN9HJPK"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-7LSEN9HJPK');
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Minato Makoto | Interactive Portfolio</title>


### PR DESCRIPTION
## Summary
- embed the Google tag (gtag.js) snippet at the top of every static page head so it loads on all site entry points

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbcb27bd0883259da3e8c34fe42137