### PR TITLE
Add mobile page to sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -10,4 +10,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://minato-makoto.github.io/mobile.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add the mobile landing page to the sitemap so it is indexed alongside existing pages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbd56c1bcc8325ac44449a7f03ecc0