### PR TITLE
Align mobile metadata with desktop portfolio page

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -13,7 +13,18 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Minato Makoto | Interactive Portfolio</title>
+  <meta name="description" content="Portfolio 3D tương tác của Lương Bảo Huy (Minato Makoto) - Video Producer, Photographer, Designer, etc.">
   <link rel="icon" type="image/x-icon" href="src/assets/20250910_091520.ico">
+  <link rel="canonical" href="https://minato-makoto.github.io/">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://minato-makoto.github.io/">
+  <meta property="og:title" content="Minato Makoto | Interactive Portfolio">
+  <meta property="og:description" content="Portfolio 3D tương tác của Lương Bảo Huy (Minato Makoto) - Video Producer, Photographer, Designer, etc.">
+  <meta property="og:image" content="https://minato-makoto.github.io/src/assets/images/og-preview.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Minato Makoto | Interactive Portfolio">
+  <meta name="twitter:description" content="Portfolio 3D tương tác của Lương Bảo Huy (Minato Makoto) - Video Producer, Photographer, Designer, etc.">
+  <meta name="twitter:image" content="https://minato-makoto.github.io/src/assets/images/og-preview.jpg">
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 


### PR DESCRIPTION
## Summary
- add the portfolio meta description and canonical URL to `mobile.html`
- include the Open Graph and Twitter card metadata on the mobile page to match the desktop experience

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbd55df3448325abee796d451a5409